### PR TITLE
updated webhook `VerifyWebHookSignature` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,27 @@ twikeyClient.Transaction.Feed(new TransactionCallbackImpl());
 When wants to inform you about new updates about documents or payments a `webhookUrl` specified in your api settings be called.  
 
 ```csharp
-string incomingSignature = request.Headers.GetValues("X-SIGNATURE").First<string>();
-string payload = request.Content.ReadAsStringAsync().Result;
+/**
+    * Formats query string from TwiKey to a query string for the webhook request validation
+    * @return query string for the webhook request validation, for example msg=dummytest&type=event
+    */
+private string ParseTwiKeyCreateQuerySubString()
+{
+    var queryParameters = HttpUtility.UrlDecode(Request.QueryString.Value);
+    
+    // question mark needs to be removed
+    if(queryParameters != null && queryParameters[0] == '?')
+    {
+        queryParameters = queryParameters.Substring(1);
+    }
+    return queryParameters;
+}
+string incomingSignature = Request.Headers["X-SIGNATURE"].First<string>();
 
-boolean valid = twikeyClient.VerifyWebHookSignature(incomingSignature,payload);
+// query parameter needs to be in the following format "msg=dummytest&type=event"
+string payload = ParseTwiKeyCreateQuerySubString();
+
+bool valid = twikeyClient.VerifyWebHookSignature(incomingSignature,payload);
 ```
 
 ## API documentation ##

--- a/src/Twikey/TwikeyClient.cs
+++ b/src/Twikey/TwikeyClient.cs
@@ -111,8 +111,8 @@ namespace Twikey
             public UnauthenticatedException() : base("Not authenticated") { }
         }
 
-        /// <param name="signatureHeader">Header("X-SIGNATURE")</param>
-        /// <param name="queryString">request.getQueryString</param>
+        /// <param name="signatureHeader">Request.Headers["X-SIGNATURE"].First<string>()</param>
+        /// <param name="queryString">Request.QueryString.Value with format "msg=dummytest&type=event"</param>
         /// <returns>True for valid signatures</returns>
         public bool VerifyWebHookSignature(string signatureHeader, string queryString)
         {


### PR DESCRIPTION
I updated the readme and code documentation for the `VerifyWebHookSignature` method. This has changed in ASP .NET core version 6 and I struggled to get it working. I hope this will help developers in the future :)