### PR TITLE
Add async support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.vs
 bin/
 obj/
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ payment options of your favorite PSP to allow other customers to pay as well.
 To use the Twikey API client, the following things are required:
 
 + Get yourself a [Twikey account](https://www.twikey.com).
-+ .NET core >= 3.1.0
++ .NET core >= 5.0
 + Up-to-date OpenSSL (or other SSL/TLS toolkit)
 
 ## Installation 
@@ -87,7 +87,7 @@ var customer = new Customer()
 };
 var profile = 123; // Profile to use
 var request = new MandateRequest(profile); // Can contain optional account data
-SignableMandate invite = twikeyClient.Document.Create(customer, request); 
+SignableMandate invite = await twikeyClient.Document.CreateAsync(customer, request); 
 ```
 
 _After creation, the link available in invite.Url can be used to redirect the customer into the signing flow or even 
@@ -99,7 +99,7 @@ send him a link through any other mechanism. Ideally you store the mandatenumber
 
 ```csharp
 //Generator to work with response from Twikey
-foreach(var mandateUpdate in twikeyClient.Document.Feed())
+foreach(var mandateUpdate in await twikeyClient.Document.FeedAsync())
 {
     if(mandateUpdate.IsNew())
     {
@@ -143,7 +143,7 @@ var invoice = new Invoice()
     Date = DateTime.Now,
     Duedate = DateTime.Now.AddDays(30),
 };
-twikeyClient.Invoice.Create(customer, invoice);
+await twikeyClient.Invoice.CreateAsync(customer, invoice);
 ```
 
 ### Feed
@@ -152,7 +152,7 @@ Retrieve the list of updates on invoices that had changes since the last call.
 
 ```csharp
 //Generator to work with response from Twikey
-foreach(var invoice in twikeyClient.Invoice.Feed())
+foreach(var invoice in await twikeyClient.Invoice.FeedAsync())
 {
     Console.WriteLine("Updated invoice: " + invoice);
 }
@@ -161,11 +161,11 @@ foreach(var invoice in twikeyClient.Invoice.Feed())
 ## Paymentlinks
 Create a payment link 
 
-**You need an integration like for example iDeal**
+**You need an integration, for example iDeal**
 
 ```csharp
 var request = new PaylinkRequest("Your payment", 10.55);
-twikeyClient.Paylink.Create(customer, request);
+await twikeyClient.Paylink.CreateAsync(customer, request);
 
 ```
 
@@ -175,7 +175,7 @@ Get payment link feed since the last retrieval
 
 ```csharp
 //Generator to work with response from Twikey
-foreach(var link in twikeyClient.Paylink.Feed())
+foreach(var link in await twikeyClient.Paylink.FeedAsync())
 {
    if(link.IsPaid())
    {
@@ -195,14 +195,14 @@ Send new transactions and act upon feedback from the bank.
 
 ```csharp
 var request = new TransactionRequest("MyMessage",10.55);
-twikeyClient.Transaction.Create(mandateNumber, request);
+await twikeyClient.Transaction.CreateAsync(mandateNumber, request);
 ```
 
 ### Feed
 
 ```csharp
 //Generator to work with response from Twikey
-foreach(var transaction in twikeyClient.Transaction.Feed())
+foreach(var transaction in await twikeyClient.Transaction.FeedAsync())
 {
     Console.WriteLine("Updated Transaction: " + transaction);
 }
@@ -229,7 +229,7 @@ private string ParseTwiKeyCreateQuerySubString()
     }
     return queryParameters;
 }
-string incomingSignature = Request.Headers["X-SIGNATURE"].First<string>();
+string incomingSignature = Request.Headers["X-SIGNATURE"].First();
 
 // query parameter needs to be in the following format "msg=dummytest&type=event"
 string payload = ParseTwiKeyCreateQuerySubString();

--- a/src/Twikey/DocumentGateway.cs
+++ b/src/Twikey/DocumentGateway.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using System.IO;
 using Twikey.Model;
+using System.Threading.Tasks;
 
 namespace Twikey
 {
@@ -20,6 +21,17 @@ namespace Twikey
         /// <exception cref="Twikey.TwikeyClient.UserException">When Twikey returns a user error (400)</exception>
         /// <returns>Url to redirect the customer to or to send in an email</returns>
         public SignableMandate Create(Customer customer, MandateRequest mandaterequest)
+        {
+            return CreateAsync(customer, mandaterequest).Result;
+        }
+
+        /// <param name="ct">Template to use can be found @ https://www.twikey.com/r/admin#/c/template</param>
+        /// <param name="customer">Customer details</param>
+        /// <param cref="MandateRequest">MandateRequest containing details about the request</param>
+        /// <exception cref="IOException">When no connection could be made</exception>
+        /// <exception cref="Twikey.TwikeyClient.UserException">When Twikey returns a user error (400)</exception>
+        /// <returns>Url to redirect the customer to or to send in an email</returns>
+        public async Task<SignableMandate> CreateAsync(Customer customer, MandateRequest mandaterequest)
         {
             var parameters = new Dictionary<string, string>();
             AddIfExists(parameters,"ct", mandaterequest.Ct);
@@ -61,18 +73,18 @@ namespace Twikey
             request.RequestUri = _twikeyClient.GetUrl("/invite");
             request.Method = HttpMethod.Post;
             request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
-            request.Headers.Add("Authorization", _twikeyClient.GetSessionToken());
+            request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
 
             request.Content = new FormUrlEncodedContent(parameters);
-            HttpResponseMessage response = _twikeyClient.Send(request);
+            HttpResponseMessage response = await _twikeyClient.SendAsync(request);
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                var responseString = response.Content.ReadAsStringAsync().Result;
+                var responseString = await response.Content.ReadAsStringAsync();
                 return JsonConvert.DeserializeObject<SignableMandate>(responseString);
             }
 
-            String apiError = response.Headers.GetValues("ApiError").First<string>();
+            string apiError = response.Headers.GetValues("ApiError").First();
             throw new TwikeyClient.UserException(apiError);
 
         }
@@ -83,46 +95,64 @@ namespace Twikey
         /// <exception cref="Twikey.TwikeyClient.UserException">When there was an issue while retrieving the mandates (eg. invalid apikey)</exception>
         public IEnumerable<MandateFeedMessage> Feed(params string[] xTypes)
         {
-            Uri myUrl = _twikeyClient.GetUrl("/mandate");
             bool isEmpty;
             do
             {
-                HttpRequestMessage request = new HttpRequestMessage();
-                request.RequestUri = myUrl;
-                request.Method = HttpMethod.Get;
-                request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
-                request.Headers.Add("Authorization", _twikeyClient.GetSessionToken());
-                if (xTypes != null && xTypes.Length != 0)
-                    request.Headers.Add("X-TYPES", string.Join(',', xTypes));
+                var messages = FeedAsync(xTypes).Result;
 
-                HttpResponseMessage response = _twikeyClient.Send(request);
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                foreach(var message in messages)
                 {
-                    var responseString = response.Content.ReadAsStringAsync().Result;
-                    var feed = JsonConvert.DeserializeObject<MandateFeed>(responseString);
-                    foreach(var message in feed.Messages)
-                    {
-                        yield return message;
-                    }
-                    isEmpty = !feed.Messages.Any();
+                    yield return message;
                 }
-                else
-                {
-                    string apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
-                    throw new TwikeyClient.UserException(apiError);
-                }
+                isEmpty = !messages.Any();
+
             } while (!isEmpty);
         }
 
+        /// Get updates about all mandates (new/updated/cancelled)
+        /// <param name="xTypes">Array of x-types. For example CORE,CREDITCARD</param>
+        /// <exception cref="IOException">When a network issue happened</exception>
+        /// <exception cref="Twikey.TwikeyClient.UserException">When there was an issue while retrieving the mandates (eg. invalid apikey)</exception>
+        public async Task<IEnumerable<MandateFeedMessage>> FeedAsync(params string[] xTypes)
+        {
+            Uri myUrl = _twikeyClient.GetUrl("/mandate");
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.RequestUri = myUrl;
+            request.Method = HttpMethod.Get;
+            request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
+            request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
+            if (xTypes != null && xTypes.Length != 0)
+                request.Headers.Add("X-TYPES", string.Join(',', xTypes));
+
+            HttpResponseMessage response = await _twikeyClient.SendAsync(request);
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                var responseString = await response.Content.ReadAsStringAsync();
+                var feed = JsonConvert.DeserializeObject<MandateFeed>(responseString);
+                
+                return feed.Messages;
+            }
+            else
+            {
+                string apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
+                throw new TwikeyClient.UserException(apiError);
+            }
+        }
+
         public void CancelMandate(string mandateId, string reason, bool notify = false)
+        {
+            CancelMandateAsync(mandateId, reason, notify).RunSynchronously();
+        }
+
+        public async Task CancelMandateAsync(string mandateId, string reason, bool notify = false)
         {
             HttpRequestMessage request = new HttpRequestMessage();
             request.RequestUri = _twikeyClient.GetUrl($"/mandate?mndtId={mandateId}&rsn={reason}{(notify ? "notify=true" : string.Empty)}");
             request.Method = HttpMethod.Delete;
             request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
-            request.Headers.Add("Authorization", _twikeyClient.GetSessionToken());
+            request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
 
-            HttpResponseMessage response = _twikeyClient.Send(request);
+            HttpResponseMessage response = await _twikeyClient.SendAsync(request);
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 return;

--- a/src/Twikey/TransactionGateway.cs
+++ b/src/Twikey/TransactionGateway.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Net.Http.Headers;
 using Twikey.Model;
 using static Twikey.TwikeyClient;
+using System.Threading.Tasks;
 
 namespace Twikey
 {
@@ -20,8 +21,18 @@ namespace Twikey
         /// <param name="transactionDetails">map with keys (message,ref,amount,place)</param>
         /// <returns cref="TransactionEntry">TransactionEntry</returns>
         /// <exception cref="IOException">When no connection could be made</exception>
-        /// <exception cref="Twikey.TwikeyClient.UserException">When Twikey returns a user error (400)</exception>
-        public Twikey.Model.TransactionEntry Create(String mandateNumber, TransactionRequest transactionDetails)
+        /// <exception cref="UserException">When Twikey returns a user error (400)</exception>
+        public TransactionEntry Create(string mandateNumber, TransactionRequest transactionDetails)
+        {
+            return CreateAsync(mandateNumber, transactionDetails).Result;
+        }
+
+        /// <param name="mandateNumber">required</param>
+        /// <param name="transactionDetails">map with keys (message,ref,amount,place)</param>
+        /// <returns cref="TransactionEntry">TransactionEntry</returns>
+        /// <exception cref="IOException">When no connection could be made</exception>
+        /// <exception cref="UserException">When Twikey returns a user error (400)</exception>
+        public async Task<TransactionEntry> CreateAsync(string mandateNumber, TransactionRequest transactionDetails)
         {
             var parameters = new Dictionary<string, string>();
             AddIfExists(parameters, "mndtId", mandateNumber);
@@ -37,26 +48,42 @@ namespace Twikey
             request.RequestUri = _twikeyClient.GetUrl("/transaction");
             request.Method = HttpMethod.Post;
             request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
-            request.Headers.Add("Authorization", _twikeyClient.GetSessionToken());
-            if (!String.IsNullOrEmpty(transactionDetails.IdempotencyKey)){
+            request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
+            if (!string.IsNullOrEmpty(transactionDetails.IdempotencyKey)){
                 request.Headers.Add("Idempotency-Key", transactionDetails.IdempotencyKey);
             }
 
             request.Content = new FormUrlEncodedContent(parameters);
-            HttpResponseMessage response = _twikeyClient.Send(request);
+            HttpResponseMessage response = await _twikeyClient.SendAsync(request);
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                var responseString = response.Content.ReadAsStringAsync().Result;
+                var responseString = await response.Content.ReadAsStringAsync();
                 var tx = JsonConvert.DeserializeObject<Transaction>(responseString);
                 return tx.Entries.ElementAtOrDefault(0);
             }
 
-            String apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
-            throw new TwikeyClient.UserException(apiError);
+            string apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
+            throw new UserException(apiError);
         }
 
         public IEnumerable<TransactionEntry> Feed(params string[] sideloads)
+        {
+            bool isEmpty;
+            do
+            {
+                var entries = FeedAsync(sideloads).Result;
+
+                foreach (var tx in entries)
+                {
+                    yield return tx;
+                }
+                isEmpty = !entries.Any();
+
+            } while (!isEmpty);
+        }
+
+        public async Task<IEnumerable<TransactionEntry>> FeedAsync(params string[] sideloads)
         {
             string url = "/transaction";
             if(sideloads != null && sideloads.Length != 0)
@@ -66,36 +93,33 @@ namespace Twikey
             }
 
             Uri myUrl = _twikeyClient.GetUrl(url);
-            bool isEmpty;
-            do
-            {
-                HttpRequestMessage request = new HttpRequestMessage();
-                request.RequestUri = myUrl;
-                request.Method = HttpMethod.Get;
-                request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
-                request.Headers.Add("Authorization", _twikeyClient.GetSessionToken());
+            
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.RequestUri = myUrl;
+            request.Method = HttpMethod.Get;
+            request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
+            request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
 
-                HttpResponseMessage response = _twikeyClient.Send(request);
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
-                {
-                    var responseText = response.Content.ReadAsStringAsync().Result;
-                    var feed = JsonConvert.DeserializeObject<Transaction>(responseText);
-                    foreach(var tx in feed.Entries)
-                    {
-                        yield return tx;
-                    }
-                    isEmpty = !feed.Entries.Any();
-                }
-                else
-                {
-                    string apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
-                    throw new TwikeyClient.UserException(apiError);
-                }
-            } while (!isEmpty);
-            yield break;
+            HttpResponseMessage response = await _twikeyClient.SendAsync(request);
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                var responseText = await response.Content.ReadAsStringAsync();
+                var feed = JsonConvert.DeserializeObject<Transaction>(responseText);
+                return feed.Entries;
+            }
+            else
+            {
+                string apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
+                throw new UserException(apiError);
+            }
         }
 
         public void RemoveTransaction(string id = null, string reference = null)
+        {
+            RemoveTransactionAsync(id, reference).RunSynchronously();
+        }
+
+        public async Task RemoveTransactionAsync(string id = null, string reference = null)
         {
             if (string.IsNullOrWhiteSpace(id) && string.IsNullOrWhiteSpace(reference))
                 throw new UserException("Either id or reference must be provided");
@@ -109,9 +133,9 @@ namespace Twikey
             request.RequestUri = _twikeyClient.GetUrl($"/transaction?{string.Join("&", p)}");
             request.Method = HttpMethod.Delete;
             request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
-            request.Headers.Add("Authorization", _twikeyClient.GetSessionToken());
+            request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
 
-            HttpResponseMessage response = _twikeyClient.Send(request);
+            HttpResponseMessage response = await _twikeyClient.SendAsync(request);
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 return;
@@ -119,7 +143,7 @@ namespace Twikey
             else
             {
                 var apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
-                throw new TwikeyClient.UserException(apiError);
+                throw new UserException(apiError);
             }
         }
     }

--- a/src/Twikey/TwikeyClient.cs
+++ b/src/Twikey/TwikeyClient.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Web;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Twikey
 {
@@ -61,7 +62,7 @@ namespace Twikey
             return this;
         }
 
-        protected internal string GetSessionToken()
+        protected internal async Task<string> GetSessionToken()
         {
             if ((JMethods.CurrentTimeMillis() - _lastLogin) > s_maxSessionAge)
             {
@@ -78,7 +79,7 @@ namespace Twikey
                 }
                 request.Content = new FormUrlEncodedContent(parameters);
 
-                HttpResponseMessage response = s_client.SendAsync(request).Result;
+                HttpResponseMessage response = await s_client.SendAsync(request);
                 try
                 {
                     _sessionToken = response.Headers.GetValues("Authorization").First<string>();
@@ -234,7 +235,12 @@ namespace Twikey
 
         public HttpResponseMessage Send(HttpRequestMessage request)
         {
-            return s_client.SendAsync(request).Result;
+            return SendAsync(request).Result;
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            return await s_client.SendAsync(request);
         }
     }
 

--- a/src/TwikeyTests/InvoiceTest.cs
+++ b/src/TwikeyTests/InvoiceTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Twikey;
 using Twikey.Model;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace TwikeyAPITests
 {
@@ -60,6 +61,28 @@ namespace TwikeyAPITests
         }
 
         [TestMethod]
+        public async Task AsyncTestCreateInvoice()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            var invoice = new Invoice()
+            {
+                Number = "Invoice" + DateTime.Now.ToString("yyyyMMdd"),
+                Title = "Invoice April",
+                Remittance = s_testVersion,
+                Amount = 10.90,
+                Date = DateTime.Now,
+                Duedate = DateTime.Now.AddDays(30),
+            };
+
+            invoice = await _api.Invoice.CreateAsync(_ct, _customer, invoice);
+            Console.WriteLine("New invoice: " + JsonConvert.SerializeObject(invoice, Formatting.Indented));
+        }
+
+        [TestMethod]
         public void TestCreateInvoiceWithCustomerNullEmtpyFields()
         {
             if (_apiKey == null)
@@ -93,6 +116,39 @@ namespace TwikeyAPITests
         }
 
         [TestMethod]
+        public async Task AsyncTestCreateInvoiceWithCustomerNullEmtpyFields()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            Customer customer = new Customer()
+            {
+                Email = "no-reply@example.com",
+                Firstname = "Twikey",
+                Lastname = "Support",
+                Street = "Derbystraat 43",
+                City = "Gent",
+                Zip = "9000",
+                Mobile = null
+            };
+            var invoice = new Invoice()
+            {
+                Number = "Invoice-2-" + DateTime.Now.ToString("yyyyMMdd"),
+                Title = "Invoice April",
+                Remittance = s_testVersion,
+                Amount = 10.90,
+                Date = DateTime.Now,
+                Duedate = DateTime.Now.AddDays(30),
+                Customer = customer,
+            };
+
+            invoice = await _api.Invoice.CreateAsync(_ct, customer, invoice);
+            Console.WriteLine("New invoice: " + JsonConvert.SerializeObject(invoice, Formatting.Indented));
+        }
+
+        [TestMethod]
         public void GetInvoiceAndDetails(){
             if (_apiKey == null)
             {
@@ -100,6 +156,20 @@ namespace TwikeyAPITests
                 return;
             }
             foreach(var invoice in _api.Invoice.Feed())
+            {
+                Console.WriteLine("Updated invoice: " + JsonConvert.SerializeObject(invoice, Formatting.Indented));
+            }
+        }
+
+        [TestMethod]
+        public async Task AsyncGetInvoiceAndDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            foreach (var invoice in await _api.Invoice.FeedAsync())
             {
                 Console.WriteLine("Updated invoice: " + JsonConvert.SerializeObject(invoice, Formatting.Indented));
             }

--- a/src/TwikeyTests/MandateTest.cs
+++ b/src/TwikeyTests/MandateTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Twikey;
 using Twikey.Model;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace TwikeyAPITests
 {
@@ -50,6 +51,18 @@ namespace TwikeyAPITests
         }
 
         [TestMethod]
+        public async Task AsyncTestInviteMandateWithoutCustomerDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            var signableMandate = await _api.Document.CreateAsync(_customer, new MandateRequest(_ct));
+            Console.WriteLine("SignableMandate: " + JsonConvert.SerializeObject(signableMandate));
+        }
+
+        [TestMethod]
         public void TestInviteMandateWithCustomerDetailsNullAndEmptyFields()
         {
             if (_apiKey == null)
@@ -72,6 +85,28 @@ namespace TwikeyAPITests
         }
 
         [TestMethod]
+        public async Task AsyncTestInviteMandateWithCustomerDetailsNullAndEmptyFields()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            Customer customer = new Customer()
+            {
+                CustomerNumber = s_testVersion,
+                Email = null,
+                Firstname = "Twikey",
+                Lastname = "Support",
+                Street = "Derbystraat 43",
+                City = "Gent",
+                Zip = "9000"
+            };
+            var signableMandate = await _api.Document.CreateAsync(customer, new MandateRequest(_ct));
+            Console.WriteLine("SignableMandate: " + JsonConvert.SerializeObject(signableMandate));
+        }
+
+        [TestMethod]
         public void TestInviteMandateCustomerDetails()
         {
             if (_apiKey == null)
@@ -80,6 +115,18 @@ namespace TwikeyAPITests
                 return;
             }
             var signableMandate = _api.Document.Create(_customer, new MandateRequest(_ct));
+            Console.WriteLine("SignableMandate: " + JsonConvert.SerializeObject(signableMandate));
+        }
+
+        [TestMethod]
+        public async Task AsyncTestInviteMandateCustomerDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            var signableMandate = await _api.Document.CreateAsync(_customer, new MandateRequest(_ct));
             Console.WriteLine("SignableMandate: " + JsonConvert.SerializeObject(signableMandate));
         }
 
@@ -101,6 +148,31 @@ namespace TwikeyAPITests
                     Console.WriteLine("Updated mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
                 }
                 else if(mandateUpdate.IsCancelled())
+                {
+                    Console.WriteLine("Cancelled mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task AsyncGetMandatesAndDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            foreach (var mandateUpdate in await _api.Document.FeedAsync())
+            {
+                if (mandateUpdate.IsNew())
+                {
+                    Console.WriteLine("New mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+                else if (mandateUpdate.IsUpdated())
+                {
+                    Console.WriteLine("Updated mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+                else if (mandateUpdate.IsCancelled())
                 {
                     Console.WriteLine("Cancelled mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
                 }
@@ -132,6 +204,31 @@ namespace TwikeyAPITests
         }
 
         [TestMethod]
+        public async Task AsyncGetMandatesAndDetailsCreditCard()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            foreach (var mandateUpdate in await _api.Document.FeedAsync("CREDITCARD"))
+            {
+                if (mandateUpdate.IsNew())
+                {
+                    Console.WriteLine("New mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+                else if (mandateUpdate.IsUpdated())
+                {
+                    Console.WriteLine("Updated mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+                else if (mandateUpdate.IsCancelled())
+                {
+                    Console.WriteLine("Cancelled mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+            }
+        }
+
+        [TestMethod]
         public void GetMandatesAndDetailsCreditCardAndWIK(){
             if (_apiKey == null)
             {
@@ -149,6 +246,31 @@ namespace TwikeyAPITests
                     Console.WriteLine("Updated mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
                 }
                 else if(mandateUpdate.IsCancelled())
+                {
+                    Console.WriteLine("Cancelled mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task AsyncGetMandatesAndDetailsCreditCardAndWIK()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            foreach (var mandateUpdate in await _api.Document.FeedAsync("CREDITCARD", "WIK"))
+            {
+                if (mandateUpdate.IsNew())
+                {
+                    Console.WriteLine("New mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+                else if (mandateUpdate.IsUpdated())
+                {
+                    Console.WriteLine("Updated mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
+                }
+                else if (mandateUpdate.IsCancelled())
                 {
                     Console.WriteLine("Cancelled mandate: " + JsonConvert.SerializeObject(mandateUpdate, Formatting.Indented));
                 }

--- a/src/TwikeyTests/PaylinkTest.cs
+++ b/src/TwikeyTests/PaylinkTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Twikey;
 using Twikey.Model;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace TwikeyAPITests
 {
@@ -54,6 +55,24 @@ namespace TwikeyAPITests
             Console.WriteLine(JsonConvert.SerializeObject(link, Formatting.Indented));
         }
 
+        // Needs integration in Twikey for example iDeal
+        [TestMethod]
+        public async Task AsyncTestCreatePaylink()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            var request = new PaylinkRequest("Your payment", 10.55)
+            {
+                Remittance = s_testVersion,
+                Ct = _ct,
+            };
+            var link = await _api.Paylink.CreateAsync(_customer, request);
+            Console.WriteLine(JsonConvert.SerializeObject(link, Formatting.Indented));
+        }
+
         [TestMethod]
         public void TestCreatePaylinkWithCustomerNullEmptyFields()
         {
@@ -81,6 +100,32 @@ namespace TwikeyAPITests
         }
 
         [TestMethod]
+        public async Task AsyncTestCreatePaylinkWithCustomerNullEmptyFields()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            Customer customer = new Customer()
+            {
+                Email = null,
+                Firstname = "Twikey",
+                Lastname = "Support",
+                Street = "Derbystraat 43",
+                City = "Gent",
+                Zip = "9000"
+            };
+
+            var request = new PaylinkRequest("Your payment", 10.55);
+            request.Remittance = s_testVersion;
+
+            var link = await _api.Paylink.CreateAsync(customer, request);
+            Console.WriteLine(JsonConvert.SerializeObject(link, Formatting.Indented));
+        }
+
+        [TestMethod]
         public void GetPaylinkAndDetails(){
             if (_apiKey == null)
             {
@@ -90,6 +135,27 @@ namespace TwikeyAPITests
             foreach(var link in _api.Paylink.Feed())
             {
                 if(link.IsPaid())
+                {
+                    Console.WriteLine("Paid paylink: " + JsonConvert.SerializeObject(link, Formatting.Indented));
+                }
+                else
+                {
+                    Console.WriteLine("Paylink: " + JsonConvert.SerializeObject(link, Formatting.Indented));
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task AsyncGetPaylinkAndDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            foreach (var link in await _api.Paylink.FeedAsync())
+            {
+                if (link.IsPaid())
                 {
                     Console.WriteLine("Paid paylink: " + JsonConvert.SerializeObject(link, Formatting.Indented));
                 }

--- a/src/TwikeyTests/TransactionTest.cs
+++ b/src/TwikeyTests/TransactionTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Twikey;
 using Twikey.Model;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace TwikeyAPITests
 {
@@ -64,6 +65,32 @@ namespace TwikeyAPITests
         }
 
         [TestMethod]
+        public async Task AsyncTestCreateTransaction()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            if (_mandateNumber == null)
+            {
+                Assert.Inconclusive("mandateNumber is null");
+                return;
+            }
+            var request = new TransactionRequest("MyMessage", 10.55);
+            // Optional though recommended
+            request.Reference = s_testVersion;
+            // Optional
+            request.Date = DateTime.Now;
+            request.Reqcolldt = DateTime.Now;
+            request.Place = "MyTest";
+            request.Refase2e = true;
+
+            var transaction = await _api.Transaction.CreateAsync(_mandateNumber, request);
+            Console.WriteLine("New transaction: " + JsonConvert.SerializeObject(transaction, Formatting.Indented));
+        }
+
+        [TestMethod]
         public void GetTransactionAndDetails(){
             if (_apiKey == null)
             {
@@ -71,6 +98,20 @@ namespace TwikeyAPITests
                 return;
             }
             foreach(var transaction in _api.Transaction.Feed())
+            {
+                Console.WriteLine("Transaction: " + JsonConvert.SerializeObject(transaction, Formatting.Indented));
+            }
+        }
+
+        [TestMethod]
+        public async Task AsyncGetTransactionAndDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+            foreach (var transaction in await _api.Transaction.FeedAsync())
             {
                 Console.WriteLine("Transaction: " + JsonConvert.SerializeObject(transaction, Formatting.Indented));
             }

--- a/src/TwikeyTests/TwikeyTests.csproj
+++ b/src/TwikeyTests/TwikeyTests.csproj
@@ -6,11 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" Version="11.0.50727.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added async support to the client library. "Result" blocks execution until the task completes, so it was completely synchronous.

If there are any questions, I can be reached at geerten@pitcrew.nl