### PR TITLE
Add details and pdf to mandate gateway

### DIFF
--- a/src/Twikey/DocumentGateway.cs
+++ b/src/Twikey/DocumentGateway.cs
@@ -228,5 +228,37 @@ namespace Twikey
                 throw new TwikeyClient.UserException(apiError);
             }
         }
+
+        /// <inheritdoc cref="PdfAsync(string)"/>
+        public Stream Pdf(string mandateId)
+        {
+            return PdfAsync(mandateId).Result;
+        }
+
+        /// <summary>
+        /// Retrieve pdf of a mandate
+        /// </summary>
+        /// <param name="mandateId">Mandate Reference</param>
+        /// <returns>Stream of the pdf document</returns>
+        /// <exception cref="TwikeyClient.UserException"></exception>
+        public async Task<Stream> PdfAsync(string mandateId)
+        {
+            HttpRequestMessage request = new HttpRequestMessage();
+            request.RequestUri = _twikeyClient.GetUrl($"/mandate/pdf?mndtId={mandateId}");
+            request.Method = HttpMethod.Get;
+            request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
+            request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
+
+            HttpResponseMessage response = await _twikeyClient.SendAsync(request);
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                return await response.Content.ReadAsStreamAsync();
+            }
+            else
+            {
+                var apiError = response.Headers.GetValues("ApiError").FirstOrDefault();
+                throw new TwikeyClient.UserException(apiError);
+            }
+        }
     }
 }

--- a/src/Twikey/DocumentGateway.cs
+++ b/src/Twikey/DocumentGateway.cs
@@ -147,7 +147,7 @@ namespace Twikey
         /// <inheritdoc cref="CancelMandateAsync(string,string,bool)"/>
         public void CancelMandate(string mandateId, string reason, bool notify)
         {
-            CancelMandateAsync(mandateId, reason, notify).RunSynchronously();
+            Task.Run(() => CancelMandateAsync(mandateId, reason, notify));
         }
 
         /// <summary>

--- a/src/Twikey/DocumentGateway.cs
+++ b/src/Twikey/DocumentGateway.cs
@@ -168,7 +168,7 @@ namespace Twikey
         public async Task CancelMandateAsync(string mandateId, string reason, bool notify)
         {
             HttpRequestMessage request = new HttpRequestMessage();
-            request.RequestUri = _twikeyClient.GetUrl($"/mandate?mndtId={mandateId}&rsn={reason}{(notify ? "notify=true" : string.Empty)}");
+            request.RequestUri = _twikeyClient.GetUrl($"/mandate?mndtId={mandateId}&rsn={reason}{(notify ? "&notify=true" : string.Empty)}");
             request.Method = HttpMethod.Delete;
             request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
             request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());

--- a/src/Twikey/Model/Mandate.cs
+++ b/src/Twikey/Model/Mandate.cs
@@ -21,11 +21,19 @@ namespace Twikey.Model
 
     public class MandateRequest
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MandateRequest"/> class.
+        /// </summary>
+        /// <param name="ct">Template to use can be found @ https://www.twikey.com/r/admin#/c/template</param>
         public MandateRequest(long ct)
         {
             this.Ct = ct;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MandateRequest"/> class.
+        /// </summary>
+        /// <param name="tc">Template to use can be found @ https://www.twikey.com/r/admin#/c/template</param>
         public MandateRequest(string tc)
         {
             this.Tc = tc;

--- a/src/Twikey/Model/MandateDetails.cs
+++ b/src/Twikey/Model/MandateDetails.cs
@@ -1,0 +1,14 @@
+﻿namespace Twikey.Model
+{
+    public class MandateDetails
+    {
+        public string State { get; set; }
+        public string Collectable { get; set; }
+        public Mandate Mandate { get; set; }
+    }
+
+    public class MandateDetailResponse
+    {
+        public Mandate Mndt { get; set; }
+    }
+}

--- a/src/Twikey/TransactionGateway.cs
+++ b/src/Twikey/TransactionGateway.cs
@@ -116,7 +116,7 @@ namespace Twikey
 
         public void RemoveTransaction(string id = null, string reference = null)
         {
-            RemoveTransactionAsync(id, reference).RunSynchronously();
+            Task.Run(() => RemoveTransactionAsync(id, reference));
         }
 
         public async Task RemoveTransactionAsync(string id = null, string reference = null)

--- a/src/Twikey/Twikey.csproj
+++ b/src/Twikey/Twikey.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <PackageId>TwikeySDK</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Company>Twikey</Company>
     <Description>.NET SDK to work with Twikey's API</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/TwikeyTests/MandateTest.cs
+++ b/src/TwikeyTests/MandateTest.cs
@@ -1,10 +1,10 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using Twikey;
 using Twikey.Model;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace TwikeyAPITests
 {
@@ -363,6 +363,52 @@ namespace TwikeyAPITests
             var details = await _api.Document.DetailsAsync(mandate.MandateNumber, true);
 
             Console.WriteLine("Mandate details:" + details);
+        }
+
+        [TestMethod]
+        public void GetMandatePdf()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = _api.Document.Create(_customer, new MandateRequest(_ct));
+
+            try
+            {
+                var pdfError = _api.Document.Pdf(mandate.MandateNumber);
+            }
+            catch (AggregateException ex)
+            {
+                if (ex.InnerExceptions.Single().Message != "err_no_contract") throw;
+
+                Console.WriteLine("Mandate has no contract, but endpoint was reached");
+            }
+        }
+
+        [TestMethod]
+        public async Task AsyncGetMandatePdf()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = await _api.Document.CreateAsync(_customer, new MandateRequest(_ct));
+
+            try
+            {
+                var pdfError = await _api.Document.PdfAsync(mandate.MandateNumber);
+            }
+            catch (TwikeyClient.UserException ex)
+            {
+                if (ex.Message != "err_no_contract") throw;
+
+                Console.WriteLine("Mandate has no contract, but endpoint was reached");
+            }
         }
     }
 }

--- a/src/TwikeyTests/MandateTest.cs
+++ b/src/TwikeyTests/MandateTest.cs
@@ -332,5 +332,37 @@ namespace TwikeyAPITests
 
             await _api.Document.CancelMandateAsync(mandate.MandateNumber, "test", true);
         }
+
+        [TestMethod]
+        public void GetMandateDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = _api.Document.Create(_customer, new MandateRequest(_ct));
+
+            var details = _api.Document.Details(mandate.MandateNumber, true);
+
+            Console.WriteLine("Mandate details:" + details);
+        }
+
+        [TestMethod]
+        public async Task Async_GetMandateDetails()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = await _api.Document.CreateAsync(_customer, new MandateRequest(_ct));
+
+            var details = await _api.Document.DetailsAsync(mandate.MandateNumber, true);
+
+            Console.WriteLine("Mandate details:" + details);
+        }
     }
 }

--- a/src/TwikeyTests/MandateTest.cs
+++ b/src/TwikeyTests/MandateTest.cs
@@ -277,5 +277,60 @@ namespace TwikeyAPITests
             }
         }
 
+        [TestMethod]
+        public void CancelMandate()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = _api.Document.Create(_customer, new MandateRequest(_ct));
+
+            _api.Document.CancelMandate(mandate.MandateNumber, "test");
+        }
+
+        [TestMethod]
+        public void CancelMandateWithNotify()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = _api.Document.Create(_customer, new MandateRequest(_ct));
+
+            _api.Document.CancelMandate(mandate.MandateNumber, "test", true);
+        }
+
+        [TestMethod]
+        public async Task AsyncCancelMandate()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = await _api.Document.CreateAsync(_customer, new MandateRequest(_ct));
+
+            await _api.Document.CancelMandateAsync(mandate.MandateNumber, "test");
+        }
+
+        [TestMethod]
+        public async Task AsyncCancelMandateWithNotify()
+        {
+            if (_apiKey == null)
+            {
+                Assert.Inconclusive("apiKey is null");
+                return;
+            }
+
+            var mandate = await _api.Document.CreateAsync(_customer, new MandateRequest(_ct));
+
+            await _api.Document.CancelMandateAsync(mandate.MandateNumber, "test", true);
+        }
     }
 }


### PR DESCRIPTION
We need the Details and PDF endpoints in the client, so I added them.

I also improved the XML documentation (see screenshot for an example) and fixed some small issues.

![image](https://github.com/twikey/twikey-api-dotnet/assets/155436077/e678cfef-b92d-4a21-b5aa-931e0e54478c)
