### PR TITLE
Add eventid flow to mandate feed

### DIFF
--- a/src/Twikey/DocumentGateway.cs
+++ b/src/Twikey/DocumentGateway.cs
@@ -113,11 +113,11 @@ namespace Twikey
         /// <exception cref="Twikey.TwikeyClient.UserException">When there was an issue while retrieving the mandates (eg. invalid apikey)</exception>
         /// <returns>A list of all updated mandates since the last call</returns>
         public async Task<IEnumerable<MandateFeedMessage>> FeedAsync(params string[] xTypes) =>
-            await FeedAsync(Array.Empty<MandateFeedIncludes>(), xTypes);
+            await FeedAsync(null, Array.Empty<MandateFeedIncludes>(), xTypes);
 
         /// <inheritdoc cref="FeedAsync(string[], string[])"/>
         /// <param name="resumeAfterEventId">Retrieve messages starting at this EventId, including messages that have already been seen</param>
-        public async Task<IEnumerable<MandateFeedMessage>> FeedAsync(IEnumerable<MandateFeedIncludes> includes, params string[] xTypes)
+        public async Task<IEnumerable<MandateFeedMessage>> FeedAsync(long? resumeAfterEventId, IEnumerable<MandateFeedIncludes> includes, params string[] xTypes)
         {
             var queryParams = includes.Any() ? "?" + string.Join("&", includes.Select(i => "include=" + i.ToString())) : string.Empty;
             Uri myUrl = _twikeyClient.GetUrl($"/mandate{queryParams}");
@@ -127,6 +127,8 @@ namespace Twikey
             request.Method = HttpMethod.Get;
             request.Headers.Add("User-Agent", _twikeyClient.UserAgent);
             request.Headers.Add("Authorization", await _twikeyClient.GetSessionToken());
+            if (resumeAfterEventId != null)
+                request.Headers.Add("X-RESUME-AFTER", resumeAfterEventId.ToString());
             if (xTypes != null && xTypes.Length != 0)
                 request.Headers.Add("X-TYPES", string.Join(',', xTypes));
 

--- a/src/Twikey/DocumentGateway.cs
+++ b/src/Twikey/DocumentGateway.cs
@@ -112,9 +112,16 @@ namespace Twikey
         /// <exception cref="IOException">When a network issue happened</exception>
         /// <exception cref="Twikey.TwikeyClient.UserException">When there was an issue while retrieving the mandates (eg. invalid apikey)</exception>
         /// <returns>A list of all updated mandates since the last call</returns>
-        public async Task<IEnumerable<MandateFeedMessage>> FeedAsync(params string[] xTypes)
+        public async Task<IEnumerable<MandateFeedMessage>> FeedAsync(params string[] xTypes) =>
+            await FeedAsync(Array.Empty<MandateFeedIncludes>(), xTypes);
+
+        /// <inheritdoc cref="FeedAsync(string[], string[])"/>
+        /// <param name="resumeAfterEventId">Retrieve messages starting at this EventId, including messages that have already been seen</param>
+        public async Task<IEnumerable<MandateFeedMessage>> FeedAsync(IEnumerable<MandateFeedIncludes> includes, params string[] xTypes)
         {
-            Uri myUrl = _twikeyClient.GetUrl("/mandate");
+            var queryParams = includes.Any() ? "?" + string.Join("&", includes.Select(i => "include=" + i.ToString())) : string.Empty;
+            Uri myUrl = _twikeyClient.GetUrl($"/mandate{queryParams}");
+
             HttpRequestMessage request = new HttpRequestMessage();
             request.RequestUri = myUrl;
             request.Method = HttpMethod.Get;

--- a/src/Twikey/Model/MandateFeed.cs
+++ b/src/Twikey/Model/MandateFeed.cs
@@ -27,6 +27,8 @@ namespace Twikey.Model
         public string CreditorSchemeId { get; set; }
         [JsonProperty("EvtTime")]
         public DateTime? EventTime { get; set; }
+        [JsonProperty("EvtId")]
+        public long? EventId { get; set; }
 
         public bool IsNew()
         {

--- a/src/Twikey/Model/MandateFeed.cs
+++ b/src/Twikey/Model/MandateFeed.cs
@@ -58,4 +58,16 @@ namespace Twikey.Model
         [JsonProperty("Rsn")]
         public string Reason { get; set; }
     }
+
+    // be careful when adding values, these get serialized verbatim to the query string
+    public enum MandateFeedIncludes
+    {
+        mandate,
+        person,
+        signature,
+        plan,
+        tracker,
+        seq,
+        cancelled_mandate
+    }
 }


### PR DESCRIPTION
To add the EventId flow I did three things:

- Add the EventId to the MandateFeedMessage
- Allow callers to set includes on the Feed call, which I did using an enum so it's clear to see which values are valid
- Allow callers to set the resume-after event Id on the Feed call, which sets the X-RESUME-AFTER header

We do not need any of the other gateways, and I understand this functionality does not work on all feed endpoints yet, so I only implemented it on the document gateway.