### PR TITLE
add Othr parameter to the Ctctdtls of the mandate feed model

### DIFF
--- a/src/Twikey/Model/Mandate.cs
+++ b/src/Twikey/Model/Mandate.cs
@@ -147,6 +147,7 @@ namespace Twikey.Model
     public class Ctctdtls
     {
         public string EmailAdr { get; set; }
+        public string Othr { get; set; }
     }
 
     public class Dbtr


### PR DESCRIPTION
When importing mandates in de Twikey portal it is possible to add the customerNumber to the import CSV. In the mandate update feed this value can be found at $.Messages[:1].Mndt.Dbtr.CtctDtls.Othr
Yet Othr was not mapped.