### PR TITLE
Feature/reworked last payment and meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .vs
 bin/
 obj/
-
+.idea/
 TestResults/

--- a/src/Twikey/Model/Invoice.cs
+++ b/src/Twikey/Model/Invoice.cs
@@ -61,7 +61,7 @@ namespace Twikey.Model
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
         [JsonIgnore]
-        public List<Meta> Meta { get; set; }
+        public Meta Meta { get; set; }
 
         [JsonProperty("lastpayment", NullValueHandling = NullValueHandling.Ignore)]
         [JsonIgnore]

--- a/src/Twikey/Model/Invoice.cs
+++ b/src/Twikey/Model/Invoice.cs
@@ -1,6 +1,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using Twikey.Model.Parameters;
 
 namespace Twikey.Model
 {
@@ -60,11 +61,11 @@ namespace Twikey.Model
 
         [JsonProperty("meta", NullValueHandling = NullValueHandling.Ignore)]
         [JsonIgnore]
-        public Dictionary<string, string> Meta { get; set; }
+        public List<Meta> Meta { get; set; }
 
         [JsonProperty("lastpayment", NullValueHandling = NullValueHandling.Ignore)]
         [JsonIgnore]
-        public Dictionary<string, string> LastPayment { get; set; }
+        public List<LastPayment> LastPayment { get; set; }
     }
 
     public class CustomDateTimeConverter : Newtonsoft.Json.Converters.IsoDateTimeConverter

--- a/src/Twikey/Model/Parameters/LastPayment.cs
+++ b/src/Twikey/Model/Parameters/LastPayment.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
+namespace Twikey.Model.Parameters;
+
+public class LastPayment
+{
+    [JsonProperty("method", NullValueHandling = NullValueHandling.Ignore)]
+    public string PaymentMethod { get; set; }
+    
+    [JsonProperty("action", NullValueHandling = NullValueHandling.Ignore)]
+    public string Action { get; set; }
+    
+    [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
+    public int Id { get; set; }
+    
+    [JsonProperty("e2e", NullValueHandling = NullValueHandling.Ignore)]
+    public string EndToEndReference { get; set; }
+    
+    [JsonProperty("pmtinf", NullValueHandling = NullValueHandling.Ignore)]
+    public string PaymentInformation { get; set; }
+    
+    [JsonProperty("iban", NullValueHandling = NullValueHandling.Ignore)]
+    public string Iban { get; set; }
+    
+    [JsonProperty("bic", NullValueHandling = NullValueHandling.Ignore)]
+    public string Bic { get; set; }
+    
+    [JsonProperty("rc", NullValueHandling = NullValueHandling.Ignore)]
+    public string ReturnCode { get; set; }
+    
+    [JsonProperty("link", NullValueHandling = NullValueHandling.Ignore)]
+    public string PaymentLink { get; set; }
+    
+    [JsonProperty("msg", NullValueHandling = NullValueHandling.Ignore)]
+    public string Message { get; set; }
+    
+    [JsonProperty("mndtId", NullValueHandling = NullValueHandling.Ignore)]
+    public string MandateId { get; set; }
+    
+    [JsonProperty("date", NullValueHandling = NullValueHandling.Ignore)]
+    public DateTime TransactionDate { get; set; }
+    
+}

--- a/src/Twikey/Model/Parameters/Meta.cs
+++ b/src/Twikey/Model/Parameters/Meta.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+
+namespace Twikey.Model.Parameters;
+
+public class Meta
+{
+    [JsonProperty("reminderLevel", NullValueHandling = NullValueHandling.Ignore)]
+    public int ReminderLevel { get; set; }
+    
+    [JsonProperty("partial", NullValueHandling = NullValueHandling.Ignore)]
+    public string Partial { get; set; }
+    
+    [JsonProperty("lastError", NullValueHandling = NullValueHandling.Ignore)]
+    public string LastError { get; set; }
+    
+    [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+    public string Name { get; set; }
+    
+    [JsonProperty("paymentMethod", NullValueHandling = NullValueHandling.Ignore)]
+    public string PaymentMethod { get; set; }
+}


### PR DESCRIPTION
Hey,

The Invoice object had some incorrect mappings that didn’t align with Twikey’s response structure. I’ve updated the mapping so that:

Meta is now correctly mapped to the Meta object (found in models)

LastPayment is now a List<LastPayment> instead of a Dictionary<string, string>, because the response maps it to a Json Array.

This should better reflect the API response and prevent issues with deserialization.

Let me know if this helps!