### PR TITLE
allow injection of HttpClient to make TwikeyClient injectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,66 @@ and configure your API key which you can find in the [Twikey merchant interface]
 TwikeyClient twikeyClient = new TwikeyClient(apiKey).WithUserAgent("myApp");
 ``` 
 
+When integrating in an ASP.NET Core application or any application that already manages `HttpClient` instances,
+prefer the overload that accepts an existing `HttpClient`:
+
+```csharp
+using var httpClient = new HttpClient();
+TwikeyClient twikeyClient = new TwikeyClient(apiKey, httpClient).WithUserAgent("myApp");
+```
+
+The passed `HttpClient` remains owned by the caller and can be created through `IHttpClientFactory`.
+
+### ASP.NET Core dependency injection
+
+To make `TwikeyClient` injectable, register it through `IHttpClientFactory` and configure handlers/policies on that named client.
+
+```csharp
+public static class TwikeyServiceCollectionExtensions
+{
+    public const string DefaultHttpClientName = "Twikey.TwikeyClient";
+
+    public static IHttpClientBuilder AddTwikeyClient(this IServiceCollection services, string apiKey, bool useTestEnvironment, string userAgent, string privateKey)
+    {
+        var builder = services.AddHttpClient(DefaultHttpClientName);
+
+        services.AddScoped(serviceProvider =>
+        {
+            var httpClient = serviceProvider
+                .GetRequiredService<IHttpClientFactory>()
+                .CreateClient(DefaultHttpClientName);
+
+            return new TwikeyClient(apiKey, httpClient, useTestEnvironment)
+                .WithUserAgent(userAgent)
+                .WithPrivateKey(privateKey)
+        });
+
+        return builder;
+    }
+}
+```
+
+```csharp
+services
+    .AddTwikeyClient(configuration["Twikey:ApiKey"], useTestEnvironment: false, userAgent: "myApp", privateKey: configuration["Twikey:PrivateKey"])
+    .AddHttpMessageHandler<MyDelegatingHandler>()
+    .AddPolicyHandler(GetRetryPolicy());
+```
+
+Then inject `TwikeyClient` where needed:
+
+```csharp
+public sealed class BillingService
+{
+    private readonly TwikeyClient _twikeyClient;
+
+    public BillingService(TwikeyClient twikeyClient)
+    {
+        _twikeyClient = twikeyClient;
+    }
+}
+```
+
 ## Documents
 
 Invite a customer to sign a SEPA mandate using a specific behaviour template (ct) that allows you to configure 
@@ -245,7 +305,7 @@ API Documentation is available in English.
 ## Want to help us make our API client even better? ##
 
 Want to help us make our API client even better? We
-take [pull requests](https://github.com/twikey/twikey-api-python/pulls). 
+take [pull requests](https://github.com/twikey/twikey-api-dotnet/pulls). 
 
 ## Support ##
 

--- a/src/Twikey/TwikeyClient.cs
+++ b/src/Twikey/TwikeyClient.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using System.Web;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -17,10 +16,11 @@ namespace Twikey
         private static readonly string s_prodEnvironment = "https://api.twikey.com/creditor";
         private static readonly string s_testEnvironment = "https://api.beta.twikey.com/creditor";
         private static readonly long s_maxSessionAge = 23 * 60 * 60 * 1000; // max 1day, but use 23 to be safe
-        private static readonly HttpClient s_client = new HttpClient();
+        private static readonly Lazy<HttpClient> s_defaultHttpClient = new(() => new HttpClient());
         private static readonly string s_saltOwn = "own";
         private readonly string _apiKey;
         private readonly string _endpoint;
+        private readonly HttpClient _injectedHttpClient;
         private long _lastLogin;
         private string _sessionToken;
         private string _privateKey;
@@ -35,9 +35,17 @@ namespace Twikey
 
         /// <param name="apiKey">API key</param>
         /// <param name="test">Use the test environment</param>
-        public TwikeyClient(string apiKey, bool test)
+        public TwikeyClient(string apiKey, bool test = false)
+            : this(apiKey, s_defaultHttpClient.Value, test)
+        { }
+
+        /// <param name="apiKey">API key</param>
+        /// <param name="httpClient">HTTP client to use for all requests. The caller owns its lifetime.</param>
+        /// <param name="test">Use the test environment</param>
+        public TwikeyClient(string apiKey, HttpClient httpClient, bool test = false)
         {
             _apiKey = apiKey;
+            _injectedHttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _endpoint = test ? s_testEnvironment : s_prodEnvironment;
             UserAgent = s_defaultUserHeader;
             Document = new DocumentGateway(this);
@@ -45,9 +53,6 @@ namespace Twikey
             Paylink = new PaylinkGateway(this);
             Transaction = new TransactionGateway(this);
         }
-
-        /// <param name="apiKey"> API key</param>
-        public TwikeyClient(string apikey) : this(apikey, false) { }
 
         public TwikeyClient WithUserAgent(string userAgent)
         {
@@ -79,7 +84,7 @@ namespace Twikey
                 }
                 request.Content = new FormUrlEncodedContent(parameters);
 
-                HttpResponseMessage response = await s_client.SendAsync(request);
+                HttpResponseMessage response = await _injectedHttpClient.SendAsync(request);
                 try
                 {
                     _sessionToken = response.Headers.GetValues("Authorization").First<string>();
@@ -240,7 +245,7 @@ namespace Twikey
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
-            return await s_client.SendAsync(request);
+            return await _injectedHttpClient.SendAsync(request);
         }
     }
 

--- a/src/TwikeyTests/TwikeyTest.cs
+++ b/src/TwikeyTests/TwikeyTest.cs
@@ -1,13 +1,70 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Twikey;
-using Twikey.Model;
 
 namespace TwikeyAPITests
 {
     [TestClass]
     public class TwikeyAPITest
     {
+        [TestMethod]
+        public async Task SendAsync_UsesInjectedHttpClient()
+        {
+            HttpRequestMessage capturedRequest = null;
+            using (var httpClient = new HttpClient(new DelegateHttpMessageHandler(request =>
+                   {
+                       capturedRequest = request;
+                       return new HttpResponseMessage(HttpStatusCode.OK);
+                   })))
+            {
+                var client = new TwikeyClient("api-key", httpClient);
+                var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/test");
+
+                var response = await client.SendAsync(request);
+
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                Assert.AreSame(request, capturedRequest);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetSessionToken_UsesInjectedHttpClientAndCachesToken()
+        {
+            int callCount = 0;
+            HttpRequestMessage capturedRequest = null;
+            using (var httpClient = new HttpClient(new DelegateHttpMessageHandler(request =>
+                   {
+                       callCount++;
+                       capturedRequest = request;
+                       var response = new HttpResponseMessage(HttpStatusCode.OK);
+                       response.Headers.Add("Authorization", "token-123");
+                       return response;
+                   })))
+            {
+                var client = new TestableTwikeyClient("api-key", httpClient, true);
+                client.WithUserAgent("twikey-api-dotnet/tests");
+
+                var token = await client.GetSessionTokenAsync();
+                var tokenAgain = await client.GetSessionTokenAsync();
+
+                Assert.AreEqual("token-123", token);
+                Assert.AreEqual("token-123", tokenAgain);
+                Assert.AreEqual(1, callCount);
+                Assert.IsNotNull(capturedRequest);
+                Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+                Assert.AreEqual(new Uri("https://api.beta.twikey.com/creditor"), capturedRequest.RequestUri);
+                Assert.AreEqual("twikey-api-dotnet/tests", capturedRequest.Headers.GetValues("User-Agent").Single());
+
+                var body = await capturedRequest.Content.ReadAsStringAsync();
+                Assert.AreEqual("apiToken=api-key", body);
+            }
+        }
+
         [TestMethod]
         public void VerifySignatureAndDecryptAccountInfo()
         {
@@ -28,6 +85,32 @@ namespace TwikeyAPITests
             string[] ibanAndBic = TwikeyClient.DecryptAccountInformation(websiteKey, doc, encryptedAccountInOutcome);
             Assert.AreEqual("BE08001166979213", ibanAndBic[0]);
             Assert.AreEqual("GEBABEBB", ibanAndBic[1]);
+        }
+
+        private sealed class TestableTwikeyClient : TwikeyClient
+        {
+            public TestableTwikeyClient(string apiKey, HttpClient httpClient, bool test)
+                : base(apiKey, httpClient, test) { }
+
+            public Task<string> GetSessionTokenAsync()
+            {
+                return base.GetSessionToken();
+            }
+        }
+
+        private sealed class DelegateHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+            public DelegateHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+            {
+                _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(_handler(request));
+            }
         }
     }
 }


### PR DESCRIPTION
This PR updates `TwikeyClient` to support modern `HttpClient` usage patterns while remaining fully backward compatible.

### What changed
- Added a new `TwikeyClient` constructor overload that accepts an injected `HttpClient`.
- Kept existing behavior intact for current consumers by preserving the default constructor path.
- Updated the internal static fallback `HttpClient` to be lazily created, so it is instantiated only when actually needed.

### Why this matters
- Enables integration with `IHttpClientFactory`  and DI-based composition.
- Makes it possible to add resilience policies (for example via Polly) on the Twikey HTTP pipeline.
- Makes it possible to plug in custom `DelegatingHandler`s (logging, auth, tracing, etc.).
- Allows `TwikeyClient` itself to be registered and injected as a service in ASP.NET Core applications without breaking existing usage patterns.